### PR TITLE
Adding react-native-webview-readability onto list of packages

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1,5 +1,12 @@
 [
   {
+    "githubUrl": "https://github.com/jeffreymendez1993/react-native-webview-readability",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": true
+  },
+  {
     "githubUrl": "https://github.com/kenkotch/react-native-columns",
     "ios": true,
     "android": true,


### PR DESCRIPTION
A cross platform Safari like readerMode component that takes any url source that displays views cleanly with noise.